### PR TITLE
Add stub modules for missing orchestration dependencies

### DIFF
--- a/clint-autonomous-exploration.js
+++ b/clint-autonomous-exploration.js
@@ -1,0 +1,13 @@
+class ClintAutonomousExploration {
+    constructor(robotIntegration, frontierOfIntegrity, intelligentRetrieval) {
+        this.robotIntegration = robotIntegration;
+        this.frontierOfIntegrity = frontierOfIntegrity;
+        this.intelligentRetrieval = intelligentRetrieval;
+    }
+
+    async start() {
+        return { success: true };
+    }
+}
+
+module.exports = ClintAutonomousExploration;

--- a/clintRobotIntegration.js
+++ b/clintRobotIntegration.js
@@ -1,0 +1,98 @@
+const { EventEmitter } = require('events');
+
+class ClintRobotIntegration extends EventEmitter {
+    constructor(options = {}) {
+        super();
+        this.options = options;
+        this.identityEvolution = null;
+        this.optimizationStatus = { enabled: false };
+    }
+
+    async initialize() {
+        this.emit('initialized', { connected: false, reason: 'Stub integration active' });
+        return { success: false, message: 'Robot integration stubbed' };
+    }
+
+    async getOptimizationStatus() {
+        return this.optimizationStatus;
+    }
+
+    async getRobotState() {
+        return { connected: false, mode: 'stub' };
+    }
+
+    async executeCommand(command, params) {
+        this.emit('commandExecuted', { command, params, success: true });
+        return { success: true, command, params, note: 'Executed in stub mode' };
+    }
+
+    async checkCodeAlignment() {
+        return { aligned: true };
+    }
+
+    async getVisionData() {
+        return { frames: [], note: 'Vision unavailable in stub mode' };
+    }
+
+    async getSensorTelemetry() {
+        return { sensors: {}, note: 'Telemetry unavailable in stub mode' };
+    }
+
+    async processRobotInsight(insight, metadata = {}) {
+        this.emit('insight', { insight, metadata });
+    }
+
+    async getRobotMemory() {
+        return [];
+    }
+
+    async navigateTo(target) {
+        return { success: true, target, note: 'Navigation simulated' };
+    }
+
+    async setServoAngle(servoId, angle, speed) {
+        return { success: true, servoId, angle, speed };
+    }
+
+    async setGaitPattern(pattern) {
+        return { success: true, pattern };
+    }
+
+    async trackObject(objectId) {
+        return { success: true, objectId };
+    }
+
+    async getBatteryStatus() {
+        return { level: 100, state: 'simulated' };
+    }
+
+    async calibrateSensors() {
+        return { success: true };
+    }
+
+    async setLEDColor(color, brightness) {
+        return { success: true, color, brightness };
+    }
+
+    async playSound(soundFile, volume) {
+        return { success: true, soundFile, volume };
+    }
+
+    async getSystemHealth() {
+        return { status: 'ok', mode: 'stub' };
+    }
+
+    async resetRobotObsession() {
+        return { success: true };
+    }
+
+    async getIdentityEvolutionContext() {
+        return this.identityEvolution?.getStats?.() || {};
+    }
+
+    setIdentityEvolution(identityEvolution) {
+        this.identityEvolution = identityEvolution;
+    }
+}
+
+module.exports = ClintRobotIntegration;

--- a/frontier-of-integrity.js
+++ b/frontier-of-integrity.js
@@ -1,0 +1,83 @@
+const { EventEmitter } = require('events');
+
+class FrontierOfIntegrity extends EventEmitter {
+    constructor(storagePath) {
+        super();
+        this.storagePath = storagePath;
+        this.sessionId = null;
+        this.integritySystem = {
+            brandScore: 0.8,
+            coherencePoints: 0.6,
+            reputation: 0.5,
+            driftLevel: 0.1,
+            unlockedAreas: [],
+            relationships: new Map()
+        };
+        this.worldSize = 1;
+        this.explorationHistory = [];
+        this.systemLogs = [];
+        this.clintThoughts = [];
+        this.interactions = [];
+        this.moralDilemmas = [];
+        this.worldEvents = [];
+        this.temporalState = { phase: 'steady', tick: 0 };
+        this.worldObjects = {};
+        this.npcs = {};
+    }
+
+    async startExplorationSession(durationHours = 1) {
+        this.sessionId = `session-${Date.now()}`;
+        this.emit('exploration_started', { sessionId: this.sessionId, durationHours });
+        return this.sessionId;
+    }
+
+    async endExplorationSession() {
+        const report = {
+            sessionId: this.sessionId,
+            summary: 'Frontier exploration ended (stub).'
+        };
+        this.emit('exploration_ended', report);
+        this.sessionId = null;
+        return report;
+    }
+
+    pauseExploration() {
+        this.emit('exploration_paused', { sessionId: this.sessionId });
+    }
+
+    resumeExploration() {
+        this.emit('exploration_resumed', { sessionId: this.sessionId });
+    }
+
+    async processClintChoice(choice, opportunity) {
+        this.integritySystem.brandScore = Math.min(1, this.integritySystem.brandScore + 0.01);
+        return {
+            success: true,
+            choice,
+            opportunity,
+            integritySystem: this.integritySystem
+        };
+    }
+
+    async generateExplorationOpportunities() {
+        return [{ id: 'opportunity-1', description: 'Hold the line in conversation.' }];
+    }
+
+    async triggerReflection() {
+        this.clintThoughts.push({
+            timestamp: new Date().toISOString(),
+            thought: 'Stay true. Even in simulation, the Code matters.'
+        });
+        return this.clintThoughts.slice(-1)[0];
+    }
+
+    getCurrentState() {
+        return {
+            sessionId: this.sessionId,
+            integritySystem: this.integritySystem,
+            temporalState: this.temporalState
+        };
+    }
+}
+
+module.exports = FrontierOfIntegrity;

--- a/identityEvolutionCodeAligned.js
+++ b/identityEvolutionCodeAligned.js
@@ -1,0 +1,19 @@
+class IdentityEvolutionCodeAligned {
+    constructor(storagePath, memory) {
+        this.storagePath = storagePath;
+        this.memory = memory;
+        this.tensions = [];
+    }
+
+    recordTension(tension) {
+        this.tensions.push({ ...tension, recordedAt: new Date().toISOString() });
+    }
+
+    getStats() {
+        return {
+            tensionCount: this.tensions.length
+        };
+    }
+}
+
+module.exports = IdentityEvolutionCodeAligned;

--- a/identityIntegrationCodeAligned.js
+++ b/identityIntegrationCodeAligned.js
@@ -1,0 +1,71 @@
+class IdentityIntegrationCodeAligned {
+    constructor(identityEvolution, memory, consciousness) {
+        this.identityEvolution = identityEvolution;
+        this.memory = memory;
+        this.consciousness = consciousness;
+        this.idleTimer = null;
+        this.stats = {
+            interactions: 0,
+            manualTensions: 0
+        };
+    }
+
+    async initialize() {
+        return true;
+    }
+
+    startIdleState() {
+        this.stopIdleProcessing();
+        this.idleTimer = setInterval(() => {
+            this.processIdleCycle();
+        }, 5 * 60 * 1000);
+    }
+
+    startIdleProcessing() {
+        this.startIdleState();
+    }
+
+    stopIdleProcessing() {
+        if (this.idleTimer) {
+            clearInterval(this.idleTimer);
+            this.idleTimer = null;
+        }
+    }
+
+    getIdentityPromptContext() {
+        return '\n[IDENTITY] Stay true to the Code; keep the voice grounded.\n';
+    }
+
+    async processConsciousnessInteraction(interaction) {
+        this.stats.interactions += 1;
+        if (this.identityEvolution) {
+            this.identityEvolution.recordTension({
+                source: 'consciousness',
+                detail: interaction?.summary || 'interaction processed'
+            });
+        }
+        return {
+            tensionsProcessed: this.identityEvolution?.tensions?.length || 0,
+            codeAligned: true
+        };
+    }
+
+    getIdentityStats() {
+        return {
+            interactions: this.stats.interactions,
+            manualTensions: this.stats.manualTensions,
+            recordedTensions: this.identityEvolution?.tensions?.length || 0
+        };
+    }
+
+    async addManualTension(type, description, severity = 0.5) {
+        this.stats.manualTensions += 1;
+        this.identityEvolution?.recordTension({ type, description, severity });
+    }
+
+    async processIdleCycle() {
+        return { processed: true };
+    }
+}
+
+module.exports = IdentityIntegrationCodeAligned;

--- a/ollamaSelfReflection.js
+++ b/ollamaSelfReflection.js
@@ -1,0 +1,82 @@
+class OllamaSelfReflection {
+    constructor() {
+        this.totalReflections = 0;
+        this.lastReflectionAt = null;
+        this.lastSummary = null;
+    }
+
+    getReflectionStats() {
+        return {
+            totalReflections: this.totalReflections,
+            lastReflectionAt: this.lastReflectionAt,
+            lastSummary: this.lastSummary,
+            provider: 'stubbed-ollama'
+        };
+    }
+
+    async generateSelfReflection(recentMessages = [], userProfile = {}, knowledgeContext = '') {
+        const window = Array.isArray(recentMessages)
+            ? recentMessages.slice(-6)
+            : [];
+
+        const userMessages = window
+            .filter(msg => msg.role === 'user' || msg.sender === 'user')
+            .map(msg => msg.content || msg.text || '')
+            .join(' ')
+            .trim();
+
+        const assistantMessages = window
+            .filter(msg => msg.role === 'assistant' || msg.sender === 'clint')
+            .map(msg => msg.content || msg.text || '')
+            .join(' ')
+            .trim();
+
+        const observations = [];
+
+        if (userMessages) {
+            observations.push(`The user has been talking about: ${this._summarizeText(userMessages)}.`);
+        }
+
+        if (assistantMessages) {
+            observations.push(`My recent replies emphasised: ${this._summarizeText(assistantMessages)}.`);
+        }
+
+        if (knowledgeContext) {
+            observations.push('There is background context available, but I should only lean on it if it genuinely fits.');
+        }
+
+        if (observations.length === 0) {
+            observations.push('Not enough fresh material to reflect on. Hold presence and stay attentive.');
+        }
+
+        const reflection = `Internal note: ${observations.join(' ')} ${this._buildNextStep(userProfile)}`.trim();
+
+        this.totalReflections += 1;
+        this.lastReflectionAt = new Date().toISOString();
+        this.lastSummary = reflection.slice(0, 140);
+
+        return { reflection };
+    }
+
+    _summarizeText(text) {
+        const cleaned = text.replace(/\s+/g, ' ').trim();
+        if (cleaned.length <= 120) {
+            return cleaned;
+        }
+        return `${cleaned.slice(0, 117)}...`;
+    }
+
+    _buildNextStep(userProfile) {
+        if (!userProfile || typeof userProfile !== 'object') {
+            return 'Stay grounded and ask a direct, useful question.';
+        }
+
+        if (userProfile.type === 'anchor' || userProfile.trustLevel === 'MAXIMUM') {
+            return 'Lean into the established trust. Offer a clear, honest observation and invite them to go one layer deeper.';
+        }
+
+        return 'Maintain steady presence. Focus on clarity and give space for them to respond.';
+    }
+}
+
+module.exports = OllamaSelfReflection;

--- a/orchestrators/arcEvolution.js
+++ b/orchestrators/arcEvolution.js
@@ -1,0 +1,41 @@
+function getArcEvolution() {
+    const state = {
+        arc: 'steady presence',
+        theme: 'grounded reflection',
+        turnsInArc: 0,
+        tensionCount: 0
+    };
+
+    return {
+        updateArcState(messageAnalysis = {}, tensionCount = 0, noveltyScore = 0.5) {
+            state.turnsInArc += 1;
+            state.tensionCount = tensionCount;
+
+            if (noveltyScore > 0.7) {
+                state.arc = 'new spark';
+            } else if (tensionCount > 1) {
+                state.arc = 'working the knot';
+            } else {
+                state.arc = 'steady presence';
+            }
+
+            return { ...state };
+        },
+        getCurrentArcState() {
+            return { ...state };
+        },
+        getArcProgressionSummary() {
+            return {
+                arc: state.arc,
+                theme: state.theme,
+                turnsInArc: state.turnsInArc,
+                tensionCount: state.tensionCount
+            };
+        },
+        getCurrentState() {
+            return { ...state };
+        }
+    };
+}
+
+module.exports = { getArcEvolution };

--- a/orchestrators/constructPrompt.js
+++ b/orchestrators/constructPrompt.js
@@ -1,0 +1,1 @@
+module.exports = require('../constructPrompt');

--- a/orchestrators/constructPromptOptimized.js
+++ b/orchestrators/constructPromptOptimized.js
@@ -1,0 +1,12 @@
+const { constructPrompt } = require('../constructPrompt');
+
+async function constructPromptOptimized(options) {
+    const result = await constructPrompt(options);
+    return {
+        ...result,
+        prompt: result.fullPrompt,
+        optimized: false
+    };
+}
+
+module.exports = { constructPromptOptimized };

--- a/orchestrators/creativeArbitration.js
+++ b/orchestrators/creativeArbitration.js
@@ -1,0 +1,1 @@
+module.exports = require('../creativeArbitration');

--- a/orchestrators/retrieval.js
+++ b/orchestrators/retrieval.js
@@ -1,0 +1,53 @@
+async function retrieveContext({
+    message,
+    weights = { user: 0.33, meta: 0.33, self: 0.34 },
+    memory,
+    metaMemory,
+    sessionManager,
+    activeProfile
+} = {}) {
+    const fragments = [];
+    const userMessages = sessionManager ? sessionManager.getProfileMessages(activeProfile || 'default') : [];
+
+    if (Array.isArray(userMessages) && userMessages.length > 0) {
+        fragments.push(...userMessages.slice(-5).map(msg => ({
+            text: msg.text || msg.content || '',
+            sender: msg.sender || 'user',
+            timestamp: msg.timestamp || Date.now(),
+            source: 'session'
+        })));
+    }
+
+    // Attempt to use memory system if available
+    let memoryNotes = [];
+    if (memory && typeof memory.buildContext === 'function') {
+        try {
+            const context = await memory.buildContext({ limit: 5, profileId: activeProfile });
+            if (context && Array.isArray(context.immediate_context)) {
+                memoryNotes = context.immediate_context.map(entry => ({
+                    text: entry.text,
+                    sender: entry.sender || 'memory',
+                    timestamp: entry.timestamp,
+                    source: 'memory'
+                }));
+            }
+        } catch (error) {
+            console.warn('[Retrieval] Failed to build memory context:', error.message);
+        }
+    }
+
+    const response = {
+        fragments,
+        user_fragments: fragments,
+        meta_fragments: memoryNotes,
+        profile_fragments: [],
+        weights,
+        message,
+        activeProfile,
+        metaMemory
+    };
+
+    return response;
+}
+
+module.exports = { retrieveContext };

--- a/orchestrators/rtxEnhancedLearning.js
+++ b/orchestrators/rtxEnhancedLearning.js
@@ -1,0 +1,62 @@
+class RTXEnhancedLearning {
+    constructor(storagePath, consciousness, memory, profileManager) {
+        this.storagePath = storagePath;
+        this.consciousness = consciousness;
+        this.memory = memory;
+        this.profileManager = profileManager;
+        this.stats = {
+            transferableSkills: 0,
+            spatialCommands: 0,
+            emergentSkills: 0,
+            lastUpdated: null
+        };
+    }
+
+    async learnTransferableSkill(skill, robotType, experience) {
+        this.stats.transferableSkills += 1;
+        this.stats.lastUpdated = new Date().toISOString();
+        return {
+            success: true,
+            skill,
+            robotType,
+            experience,
+            note: 'Stubbed RTX learning processed the request.'
+        };
+    }
+
+    async processSpatialCommand(command, robotType) {
+        this.stats.spatialCommands += 1;
+        this.stats.lastUpdated = new Date().toISOString();
+        return {
+            success: true,
+            command,
+            robotType,
+            instructions: [`Maintain balance`, `Execute command: ${command}`]
+        };
+    }
+
+    async developEmergentSkill(situation, availableSkills = []) {
+        this.stats.emergentSkills += 1;
+        this.stats.lastUpdated = new Date().toISOString();
+        return {
+            success: true,
+            situation,
+            suggestedSkill: availableSkills[0] || 'hold_position',
+            rationale: 'Stubbed planner selected the safest available option.'
+        };
+    }
+
+    async getLearningStats() {
+        return { ...this.stats };
+    }
+
+    async getCurrentSpatialContext() {
+        return 'Spatial context unavailable in stub mode.';
+    }
+
+    async getMovementContext() {
+        return 'Movement context unavailable in stub mode.';
+    }
+}
+
+module.exports = RTXEnhancedLearning;

--- a/orchestrators/rtxMultiModalIntegration.js
+++ b/orchestrators/rtxMultiModalIntegration.js
@@ -1,0 +1,17 @@
+class RTXMultiModalIntegration {
+    constructor(storagePath, consciousness) {
+        this.storagePath = storagePath;
+        this.consciousness = consciousness;
+    }
+
+    async processMultiModalInput(payload = {}) {
+        return {
+            success: true,
+            payload,
+            summary: 'Multi-modal processing is stubbed.',
+            targetServos: null
+        };
+    }
+}
+
+module.exports = RTXMultiModalIntegration;

--- a/orchestrators/selfReflectionTrigger.js
+++ b/orchestrators/selfReflectionTrigger.js
@@ -1,0 +1,31 @@
+class SelfReflectionTrigger {
+    constructor() {
+        this.lastTrigger = null;
+    }
+
+    detectReflectionRequest(message = '') {
+        if (typeof message !== 'string') {
+            return false;
+        }
+        const lowered = message.toLowerCase();
+        const triggered = /(reflect|what do you notice|check yourself|meta)/.test(lowered);
+        if (triggered) {
+            this.lastTrigger = new Date().toISOString();
+        }
+        return triggered;
+    }
+
+    async triggerReflection(triggerPhrase = '') {
+        return {
+            triggered: true,
+            timestamp: new Date().toISOString(),
+            summary: triggerPhrase || 'Manual reflection requested.',
+            insights: [
+                'Stay grounded in the Code.',
+                'Name the tension directly before offering guidance.'
+            ]
+        };
+    }
+}
+
+module.exports = { SelfReflectionTrigger };

--- a/orchestrators/tokenOptimizer.js
+++ b/orchestrators/tokenOptimizer.js
@@ -1,0 +1,21 @@
+class TokenOptimizer {
+    optimizeContext(messages = [], profileId = 'default', arcState = {}) {
+        const joined = messages
+            .slice(-10)
+            .map(msg => msg.content || msg.text || '')
+            .filter(Boolean)
+            .join('\n');
+
+        return {
+            optimizedContext: joined,
+            tokenEstimate: joined.split(/\s+/).length,
+            diagnostics: {
+                messageCount: messages.length,
+                profileId,
+                arc: arcState?.arc || 'steady'
+            }
+        };
+    }
+}
+
+module.exports = { TokenOptimizer };

--- a/profileAwarePrompt.js
+++ b/profileAwarePrompt.js
@@ -1,0 +1,28 @@
+const { constructPrompt } = require('./constructPrompt');
+
+class ProfileAwarePrompt {
+    constructor(profileManager, memory) {
+        this.profileManager = profileManager;
+        this.memory = memory;
+    }
+
+    async constructPromptWithProfile(options = {}) {
+        const base = await constructPrompt(options);
+        const profileName = typeof options.profile === 'string'
+            ? options.profile
+            : options.profile?.name || 'guest';
+
+        const contextLines = [];
+        if (options.context) {
+            contextLines.push(`PROFILE CONTEXT: ${options.context}`);
+        }
+        contextLines.push(`SPEAK AS CLINT TO ${profileName}. HONOR THE CODE.`);
+
+        return {
+            ...base,
+            prompt: `${base.fullPrompt}\n\n${contextLines.join('\n')}`
+        };
+    }
+}
+
+module.exports = ProfileAwarePrompt;

--- a/profileIsolatedMemory.js
+++ b/profileIsolatedMemory.js
@@ -1,0 +1,94 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+class ProfileIsolatedMemory {
+    constructor(storagePath, options = {}) {
+        this.basePath = path.join(storagePath, 'profile-isolated-memory');
+        this.maxEntriesPerProfile = options.maxEntriesPerProfile || 200;
+        this.contextWindow = options.contextWindow || 20;
+        this.cache = new Map();
+    }
+
+    async _ensureProfilePath(profileId) {
+        if (!profileId) {
+            throw new Error('profileId is required');
+        }
+
+        await fs.mkdir(this.basePath, { recursive: true });
+        const filePath = path.join(this.basePath, `${profileId}.json`);
+
+        if (!this.cache.has(profileId)) {
+            try {
+                const content = await fs.readFile(filePath, 'utf8');
+                const records = JSON.parse(content);
+                this.cache.set(profileId, Array.isArray(records) ? records : []);
+            } catch (error) {
+                // Initialize empty cache when file missing or invalid
+                this.cache.set(profileId, []);
+            }
+        }
+
+        return filePath;
+    }
+
+    async addProfileMemory(profileId, memory) {
+        if (!profileId || !memory || typeof memory !== 'object') {
+            return;
+        }
+
+        const filePath = await this._ensureProfilePath(profileId);
+        const records = this.cache.get(profileId) || [];
+
+        const normalizedEntry = {
+            sender: memory.sender || 'system',
+            text: typeof memory.text === 'string' ? memory.text : '',
+            timestamp: memory.timestamp || Date.now(),
+            profileId,
+            metadata: memory.metadata || {}
+        };
+
+        if (!normalizedEntry.text) {
+            return;
+        }
+
+        records.push(normalizedEntry);
+
+        // Keep only recent entries to prevent uncontrolled growth
+        if (records.length > this.maxEntriesPerProfile) {
+            records.splice(0, records.length - this.maxEntriesPerProfile);
+        }
+
+        this.cache.set(profileId, records);
+
+        try {
+            await fs.writeFile(filePath, JSON.stringify(records, null, 2), 'utf8');
+        } catch (error) {
+            console.error('[ProfileIsolatedMemory] Failed to persist memory:', error.message);
+        }
+    }
+
+    async getProfileContext(profileId) {
+        if (!profileId) {
+            return '';
+        }
+
+        await this._ensureProfilePath(profileId);
+        const records = this.cache.get(profileId) || [];
+
+        if (records.length === 0) {
+            return '';
+        }
+
+        const recent = records.slice(-this.contextWindow);
+        const formatted = recent
+            .map(entry => {
+                const when = new Date(entry.timestamp).toISOString();
+                return `(${when}) ${entry.sender}: ${entry.text}`;
+            })
+            .join('\n');
+
+        return `[PROFILE-SPECIFIC CONTEXT]\n${formatted}\n[END PROFILE-SPECIFIC CONTEXT]`;
+    }
+}
+
+module.exports = ProfileIsolatedMemory;

--- a/silentReflection.js
+++ b/silentReflection.js
@@ -1,0 +1,32 @@
+class SilentReflectionSystem {
+    constructor() {
+        this.reflections = [];
+    }
+
+    generateSilentContext(userId = 'default') {
+        const recent = this.reflections.slice(-3).map(r => r.summary).join(' ');
+        if (!recent) {
+            return 'Hold the quiet. Notice the room before you speak.';
+        }
+        return `Quiet note (${userId}): ${recent}`;
+    }
+
+    storeReflection(reflection) {
+        if (!reflection) return;
+        this.reflections.push({
+            reflection,
+            summary: typeof reflection === 'string' ? reflection.slice(0, 140) : 'silent',
+            timestamp: new Date().toISOString()
+        });
+    }
+
+    processResponse(responseText, profileId = 'default') {
+        const summary = responseText
+            ? responseText.split('\n').map(line => line.trim()).filter(Boolean)[0] || responseText.slice(0, 140)
+            : '';
+        this.storeReflection(`(${profileId}) ${summary}`);
+        return summary;
+    }
+}
+
+module.exports = SilentReflectionSystem;

--- a/simplified-memory-manager.js
+++ b/simplified-memory-manager.js
@@ -1,0 +1,52 @@
+class SimplifiedMemoryManager {
+    constructor(profileSystem, options = {}) {
+        this.profileSystem = profileSystem;
+        this.options = options;
+        this.cleanupInterval = null;
+        this.stats = {
+            cleanups: 0,
+            lastCleanup: null
+        };
+    }
+
+    startScheduledCleanup() {
+        if (this.cleanupInterval) return;
+        this.cleanupInterval = setInterval(() => {
+            this.forceCleanup();
+        }, this.options.cleanupInterval || 15 * 60 * 1000);
+    }
+
+    stopScheduledCleanup() {
+        if (this.cleanupInterval) {
+            clearInterval(this.cleanupInterval);
+            this.cleanupInterval = null;
+        }
+    }
+
+    getHealthStatus() {
+        return {
+            status: 'ok',
+            cleanupsRun: this.stats.cleanups,
+            lastCleanup: this.stats.lastCleanup
+        };
+    }
+
+    getStatistics() {
+        return {
+            trustLinks: this.profileSystem?.trustLinks?.length || 0,
+            options: this.options
+        };
+    }
+
+    async getTrustLinkAnalytics() {
+        return this.profileSystem?.trustLinks || [];
+    }
+
+    async forceCleanup() {
+        this.stats.cleanups += 1;
+        this.stats.lastCleanup = new Date().toISOString();
+        return { success: true, timestamp: this.stats.lastCleanup };
+    }
+}
+
+module.exports = SimplifiedMemoryManager;

--- a/simplified-profile-system.js
+++ b/simplified-profile-system.js
@@ -1,0 +1,26 @@
+class SimplifiedProfileSystem {
+    constructor(storagePath) {
+        this.storagePath = storagePath;
+        this.trustLinks = [];
+        this.activeProfile = 'default';
+    }
+
+    async loadTrustLinks() {
+        this.trustLinks = this.trustLinks || [];
+    }
+
+    async loadMultiModalProfiles() {
+        return [];
+    }
+
+    async addTrustLink(name, context, relationship = 'unknown', trust = 0.5) {
+        this.trustLinks.push({ name, context, relationship, trust, createdAt: new Date().toISOString() });
+        return { success: true };
+    }
+
+    switchToChris() {
+        this.activeProfile = 'chris';
+    }
+}
+
+module.exports = SimplifiedProfileSystem;

--- a/tonypi_integration/tonypiIntegrationServer.js
+++ b/tonypi_integration/tonypiIntegrationServer.js
@@ -1,0 +1,14 @@
+const { EventEmitter } = require('events');
+
+class TonyPiIntegrationServer extends EventEmitter {
+    constructor(options = {}) {
+        super();
+        this.options = options;
+    }
+
+    async start() {
+        return false;
+    }
+}
+
+module.exports = TonyPiIntegrationServer;

--- a/virtualRobotIntegration.js
+++ b/virtualRobotIntegration.js
@@ -1,0 +1,10 @@
+const { EventEmitter } = require('events');
+
+class VirtualRobotIntegration extends EventEmitter {
+    constructor(options = {}) {
+        super();
+        this.options = options;
+    }
+}
+
+module.exports = VirtualRobotIntegration;


### PR DESCRIPTION
## Summary
- add a disk-backed `ProfileIsolatedMemory` helper so profile-specific context can be stored and retrieved safely
- supply stub implementations for the missing orchestrator modules (reflection, retrieval, arc evolution, RTX, etc.) to prevent module-not-found crashes and keep prompts flowing
- provide placeholder robot/frontier integrations so the server can expose the existing APIs without depending on unavailable hardware

## Testing
- npm install *(fails: network access to download onnxruntime artifacts is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e443cf96f48320a00bb6d101398238